### PR TITLE
add arm64

### DIFF
--- a/sys-boot/raspberrypi-firmware/raspberrypi-firmware-1.20180328.ebuild
+++ b/sys-boot/raspberrypi-firmware/raspberrypi-firmware-1.20180328.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/raspberrypi/firmware/archive/${PV}.tar.gz -> ${P}.ta
 
 LICENSE="GPL-2 raspberrypi-videocore-bin"
 SLOT="0"
-KEYWORDS="~arm -*"
+KEYWORDS="~arm ~arm64 -*"
 IUSE=""
 
 DEPEND=""


### PR DESCRIPTION
builds on scale away chroot , can add to gentoo-arm64 rpi3 running on my desk...